### PR TITLE
Return error if writer is nil

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"unicode/utf8"
@@ -286,14 +287,14 @@ func discardInput(r io.Reader, n uint64) {
 }
 
 // WriteMessageN writes a bitcoin Message to w including the necessary header
-// information and returns the number of bytes written.    This function is the
+// information and returns the number of bytes written. This function is the
 // same as WriteMessage except it also returns the number of bytes written.
 func WriteMessageN(w io.Writer, msg Message, pver uint32, bsvnet BitcoinNet) (int, error) {
 	return WriteMessageWithEncodingN(w, msg, pver, bsvnet, BaseEncoding)
 }
 
 // WriteMessage writes a bitcoin Message to w including the necessary header
-// information.  This function is the same as WriteMessageN except it doesn't
+// information.  This function is the same as WriteMessageN except it
 // doesn't return the number of bytes written.  This function is mainly provided
 // for backwards compatibility with the original API, but it's also useful for
 // callers that don't care about byte counts.
@@ -309,6 +310,10 @@ func WriteMessage(w io.Writer, msg Message, pver uint32, bsvnet BitcoinNet) erro
 // messages.
 func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 	bsvnet BitcoinNet, encoding MessageEncoding) (int, error) {
+
+	if w == nil {
+		return 0, errors.New("writer must not be nil")
+	}
 
 	totalBytes := 0
 
@@ -366,10 +371,8 @@ func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 	// Write header and payload in 1 go.
 	// This w.Write() is locking, so we don't have to worry about concurrent writes.
 	var n int
-	if hw != nil {
-		n, err = w.Write(append(hw.Bytes(), payload...))
-		totalBytes += n
-	}
+	n, err = w.Write(append(hw.Bytes(), payload...))
+	totalBytes += n
 
 	return totalBytes, err
 }
@@ -378,7 +381,7 @@ func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 // from r for the provided protocol version and bitcoin network.  It returns the
 // number of bytes read in addition to the parsed Message and raw bytes which
 // comprise the message.  This function is the same as ReadMessageN except it
-// allows the caller to specify which message encoding is to to consult when
+// allows the caller to specify which message encoding is to consult when
 // decoding wire messages.
 func ReadMessageWithEncodingN(r io.Reader, pver uint32, bsvnet BitcoinNet, enc MessageEncoding) (int, Message, []byte, error) {
 

--- a/wire/message.go
+++ b/wire/message.go
@@ -366,8 +366,10 @@ func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 	// Write header and payload in 1 go.
 	// This w.Write() is locking, so we don't have to worry about concurrent writes.
 	var n int
-	n, err = w.Write(append(hw.Bytes(), payload...))
-	totalBytes += n
+	if hw != nil {
+		n, err = w.Write(append(hw.Bytes(), payload...))
+		totalBytes += n
+	}
 
 	return totalBytes, err
 }


### PR DESCRIPTION
Panics can happen in the function `WriteMessageWithEncodingN()`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xc22067]

goroutine 109 [running]:
github.com/libsv/go-p2p/wire.WriteMessageWithEncodingN({0x0, 0x0}, {0x27dfbc8, 0xc0224da7b8}, 0x8a27b8?, 0xe8f3e1e3, 0xce3ad94?)
	/home/runner/go/pkg/mod/github.com/libsv/go-p2p@v0.1.6/wire/message.go:369 +0x747
github.com/libsv/go-p2p/wire.WriteMessageN(...)
	/home/runner/go/pkg/mod/github.com/libsv/go-p2p@v0.1.6/wire/message.go:292
github.com/libsv/go-p2p/wire.WriteMessage({0x0?, 0x0?}, {0x27dfbc8?, 0xc0224da7b8?}, 0x540be400?, 0x2?)
	/home/runner/go/pkg/mod/github.com/libsv/go-p2p@v0.1.6/wire/message.go:301 +0x2e
github.com/libsv/go-p2p.(*Peer).writeRetry.func1()
```

The panic may happen if the buffer `hw` is nil