### PR TITLE
Fix/user agent option

### DIFF
--- a/Peer.go
+++ b/Peer.go
@@ -100,8 +100,12 @@ func NewPeer(logger *slog.Logger, address string, peerHandler PeerHandlerI, netw
 		batchDelay:         defaultBatchDelayMilliseconds * time.Millisecond,
 	}
 
+	var err error
 	for _, option := range options {
-		option(p)
+		err = option(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply option, %v", err)
+		}
 	}
 
 	p.initialize()

--- a/Peer.go
+++ b/Peer.go
@@ -646,7 +646,9 @@ func (p *Peer) versionMessage(address string) *wire.MsgVersion {
 
 	if p.userAgentName != nil && p.userAgentVersion != nil {
 		err = msg.AddUserAgent(*p.userAgentName, *p.userAgentVersion)
-		p.logger.Error("Failed to add user agent", slog.String(errKey, err.Error()))
+		if err != nil {
+			p.logger.Error("Failed to add user agent", slog.String(errKey, err.Error()))
+		}
 	}
 
 	return msg

--- a/Peer_Options.go
+++ b/Peer_Options.go
@@ -1,39 +1,49 @@
 package p2p
 
 import (
+	"fmt"
 	"net"
 	"time"
 )
 
-type PeerOptions func(p *Peer)
+type PeerOptions func(p *Peer) error
 
 func WithDialer(dial func(network, address string) (net.Conn, error)) PeerOptions {
-	return func(p *Peer) {
+	return func(p *Peer) error {
 		p.dial = dial
+		return nil
 	}
 }
 
 func WithBatchDelay(batchDelay time.Duration) PeerOptions {
-	return func(p *Peer) {
+	return func(p *Peer) error {
 		p.batchDelay = batchDelay
+		return nil
 	}
 }
 
 func WithIncomingConnection(conn net.Conn) PeerOptions {
-	return func(p *Peer) {
+	return func(p *Peer) error {
 		p.incomingConn = conn
+		return nil
 	}
 }
 
 func WithMaximumMessageSize(maximumMessageSize int64) PeerOptions {
-	return func(p *Peer) {
+	return func(p *Peer) error {
 		p.maximumMessageSize = maximumMessageSize
+		return nil
 	}
 }
 
 func WithUserAgent(userAgentName string, userAgentVersion string) PeerOptions {
-	return func(p *Peer) {
+	return func(p *Peer) error {
+		if userAgentName == "" || userAgentVersion == "" {
+			return fmt.Errorf("both user agent name '%s' and version '%s' must not be empty strings", userAgentName, userAgentVersion)
+		}
+
 		p.userAgentName = &userAgentName
 		p.userAgentVersion = &userAgentVersion
+		return nil
 	}
 }

--- a/peer_integration_test.go
+++ b/peer_integration_test.go
@@ -94,7 +94,7 @@ func TestNewPeer(t *testing.T) {
 
 		time.Sleep(5 * time.Second)
 
-		peer, err := NewPeer(logger, "localhost:"+p2pPortBinding, peerHandler, wire.TestNet)
+		peer, err := NewPeer(logger, "localhost:"+p2pPortBinding, peerHandler, wire.TestNet, WithUserAgent("agent", "0.0.1"))
 		require.NoError(t, err)
 
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
- Log error only if error is unequal nil
- Allow only non-empty strings for user agent