### PR TITLE
Fix/write reconnect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deps:
 
 .PHONY: test
 test:
-	go test -race -count=1 ./...
+	go test -race -v -count=1 ./...
 
 .PHONY: lint
 lint:

--- a/peer_options.go
+++ b/peer_options.go
@@ -47,3 +47,10 @@ func WithUserAgent(userAgentName string, userAgentVersion string) PeerOptions {
 		return nil
 	}
 }
+
+func WithRetryReadWriteMessageInterval(d time.Duration) PeerOptions {
+	return func(p *Peer) error {
+		p.retryReadWriteMessageInterval = d
+		return nil
+	}
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -126,6 +126,7 @@ func TestReconnect(t *testing.T) {
 				WithDialer(func(network, address string) (net.Conn, error) {
 					return peerConn, nil
 				}),
+				WithRetryReadWriteMessageInterval(200*time.Millisecond),
 			)
 			require.NoError(t, err)
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -169,6 +169,7 @@ func TestReconnect(t *testing.T) {
 			// wait until peer is disconnected
 			for {
 				if !p.Connected() {
+					t.Log("disconnected")
 					break
 				}
 				count++
@@ -181,7 +182,9 @@ func TestReconnect(t *testing.T) {
 			// recreate connection
 			peerConn, myConn = connutil.AsyncPipe()
 			t.Log("new connection created")
+			time.Sleep(5 * time.Second)
 
+			t.Log("handshake")
 			doHandshake(t, p, myConn)
 			for {
 				if p.Connected() {
@@ -194,7 +197,10 @@ func TestReconnect(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 
+			t.Log("shutdown")
 			p.Shutdown()
+
+			time.Sleep(5 * time.Second)
 		})
 	}
 }

--- a/peer_test.go
+++ b/peer_test.go
@@ -98,6 +98,106 @@ func TestWriteMsg(t *testing.T) {
 	})
 }
 
+func TestReconnect(t *testing.T) {
+	tt := []struct {
+		name       string
+		cancelRead bool
+	}{
+		{
+			name:       "writer connection breaks - reconnect",
+			cancelRead: true,
+		},
+		{
+			name: "reader connection breaks - reconnect",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			peerConn, myConn := connutil.AsyncPipe()
+
+			peerHandler := NewMockPeerHandler()
+			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			p, err := NewPeer(
+				logger,
+				"MockPeerHandler:0000",
+				peerHandler,
+				wire.MainNet,
+				WithDialer(func(network, address string) (net.Conn, error) {
+					return peerConn, nil
+				}),
+			)
+			require.NoError(t, err)
+
+			doHandshake(t, p, myConn)
+
+			// wait for the peer to be connected
+			count := 0
+			for {
+				if p.Connected() {
+					break
+				}
+				count++
+				if count >= 3 {
+					t.Error("peer not connected")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			invMsg := wire.NewMsgInv()
+			hash, err := chainhash.NewHashFromStr(tx1)
+			require.NoError(t, err)
+			err = invMsg.AddInvVect(wire.NewInvVect(wire.InvTypeTx, hash))
+			require.NoError(t, err)
+
+			if tc.cancelRead {
+				// cancel reader and ensure writer will disconnect
+				p.cancelReadHandler()
+			} else {
+				// cancel writer and ensure reader will disconnect
+				p.cancelWriteHandler()
+			}
+
+			// break connection
+			err = myConn.Close()
+			require.NoError(t, err)
+
+			err = p.WriteMsg(invMsg)
+			require.NoError(t, err)
+
+			// wait until peer is disconnected
+			for {
+				if !p.Connected() {
+					break
+				}
+				count++
+				if count >= 50 {
+					t.Fatal("peer connection not broken")
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+
+			// recreate connection
+			peerConn, myConn = connutil.AsyncPipe()
+			t.Log("new connection created")
+
+			doHandshake(t, p, myConn)
+			for {
+				if p.Connected() {
+					break
+				}
+				count++
+				if count >= 20 {
+					t.Fatal("peer connection not established")
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			p.Shutdown()
+		})
+	}
+}
+
 func Test_readHandler(t *testing.T) {
 	t.Run("read message - inv tx", func(t *testing.T) {
 		myConn, _, peerHandler := newTestPeer(t)


### PR DESCRIPTION
- Disconnect completely and try to reconnect, not only upon repeated failure to read but also repeated failure to write
- Add unit test case where reconnection is triggered by failure to write
- Add unit test case where reconnection is triggered by failure to read
- Option to set the interval of retries