### PR TITLE
Feature/shutdown restart

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -31,6 +31,8 @@ type PeerI interface {
 	RequestBlock(blockHash *chainhash.Hash)
 	Network() wire.BitcoinNet
 	IsHealthy() bool
+	Shutdown()
+	Restart()
 }
 
 type PeerHandlerI interface {

--- a/interface.go
+++ b/interface.go
@@ -18,6 +18,7 @@ type PeerManagerI interface {
 	RequestBlock(blockHash *chainhash.Hash) PeerI
 	AddPeer(peer PeerI) error
 	GetPeers() []PeerI
+	Shutdown()
 }
 
 type PeerI interface {

--- a/peer.go
+++ b/peer.go
@@ -781,7 +781,7 @@ func (p *Peer) pingHandler() {
 		case <-pingTicker.C:
 			nonce, err := wire.RandomUint64()
 			if err != nil {
-				p.logger.Error("Not sending ping", slog.String(errKey, err.Error()))
+				p.logger.Error("Failed to create random nonce - not sending ping", slog.String(errKey, err.Error()))
 				continue
 			}
 			p.writeChan <- wire.NewMsgPing(nonce)

--- a/peer.go
+++ b/peer.go
@@ -813,6 +813,7 @@ func (p *Peer) monitorConnectionHealth() {
 		case <-checkConnectionHealthTicker.C:
 			p.mu.Lock()
 			p.isHealthy = false
+			p.logger.Warn("peer unhealthy")
 			p.mu.Unlock()
 		case <-p.ctx.Done():
 			return

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -67,6 +67,12 @@ func (pm *PeerManager) GetPeers() []PeerI {
 	return peers
 }
 
+func (pm *PeerManager) Shutdown() {
+	for _, peer := range pm.peers {
+		peer.Shutdown()
+	}
+}
+
 // AnnounceTransaction will send an INV message to the provided peers or to selected peers if peers is nil
 // it will return the peers that the transaction was actually announced to
 func (pm *PeerManager) AnnounceTransaction(txHash *chainhash.Hash, peers []PeerI) []PeerI {

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -80,11 +80,15 @@ func (pm *PeerManager) AnnounceTransaction(txHash *chainhash.Hash, peers []PeerI
 		peers = pm.GetAnnouncedPeers()
 	}
 
+	announcedPeers := make([]PeerI, 0, len(peers))
 	for _, peer := range peers {
-		peer.AnnounceTransaction(txHash)
+		if peer.Connected() && peer.IsHealthy() {
+			peer.AnnounceTransaction(txHash)
+			announcedPeers = append(announcedPeers, peer)
+		}
 	}
 
-	return peers
+	return announcedPeers
 }
 
 func (pm *PeerManager) RequestTransaction(txHash *chainhash.Hash) PeerI {

--- a/peer_mock.go
+++ b/peer_mock.go
@@ -121,12 +121,8 @@ func (p *PeerMock) message(msg wire.Message) {
 	p.messages = append(p.messages, msg)
 }
 
-// func (p *PeerMock) getMessages() []wire.Message {
-// 	p.mu.Lock()
-// 	defer p.mu.Unlock()
-
-// 	return p.messages
-// }
+func (p *PeerMock) Shutdown() {}
+func (p *PeerMock) Restart()  {}
 
 func (p *PeerMock) WriteMsg(msg wire.Message) error {
 	p.writeChan <- msg

--- a/peer_options.go
+++ b/peer_options.go
@@ -54,3 +54,10 @@ func WithRetryReadWriteMessageInterval(d time.Duration) PeerOptions {
 		return nil
 	}
 }
+
+func WithNrOfWriteHandlers(NrWriteHandlers int) PeerOptions {
+	return func(p *Peer) error {
+		p.nrWriteHandlers = NrWriteHandlers
+		return nil
+	}
+}


### PR DESCRIPTION
- Peer can be restarted from outside
- Peer & peer manager can be shutdown from outside
- Peer manager announce transaction function returns peers to which transaction was actually announced
- Option to set nr of write handlers