### PR TITLE
refactor peer health monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ lint:
 .PHONY: install
 install:
 	go install honnef.co/go/tools/cmd/staticcheck@latest
+
+.PHONY: gen_go
+gen_go:
+	go generate ./...

--- a/interface.go
+++ b/interface.go
@@ -29,6 +29,7 @@ type PeerI interface {
 	RequestBlock(blockHash *chainhash.Hash)
 	Network() wire.BitcoinNet
 	IsHealthy() bool
+	IsUnhealthyCh() <-chan struct{}
 	Shutdown()
 	Restart()
 }

--- a/peer.go
+++ b/peer.go
@@ -40,8 +40,8 @@ const (
 	retryReadWriteMessageAttempts        = 5
 	reconnectInterval                    = 10 * time.Second
 
-	pingIntervalDefault                   = 30 * time.Second
-	connectionHealthTickerDurationDefault = 1 * time.Minute
+	pingIntervalDefault                   = 2 * time.Minute
+	connectionHealthTickerDurationDefault = 3 * time.Minute
 )
 
 type Block struct {

--- a/peer.go
+++ b/peer.go
@@ -855,26 +855,6 @@ func (p *Peer) IsHealthy() bool {
 	return p.isHealthy.Load()
 }
 
-func (p *Peer) stopReadHandler() {
-	if p.cancelReadHandler == nil {
-		return
-	}
-	p.logger.Debug("Cancelling read handlers")
-	p.cancelReadHandler()
-	p.logger.Debug("Waiting for read handlers to stop")
-	p.readerWg.Wait()
-}
-
-func (p *Peer) stopWriteHandler() {
-	if p.cancelWriteHandler == nil {
-		return
-	}
-	p.logger.Debug("Cancelling write handlers")
-	p.cancelWriteHandler()
-	p.logger.Debug("Waiting for writer handlers to stop")
-	p.writerWg.Wait()
-}
-
 func (p *Peer) Restart() {
 	p.Shutdown()
 

--- a/peer.go
+++ b/peer.go
@@ -137,6 +137,9 @@ func NewPeer(logger *slog.Logger, address string, peerHandler PeerHandlerI, netw
 }
 
 func (p *Peer) start() {
+
+	p.logger.Info("Starting peer")
+
 	ctx, cancelAll := context.WithCancel(context.Background())
 	p.cancelAll = cancelAll
 	p.ctx = ctx
@@ -886,10 +889,14 @@ func (p *Peer) Restart() {
 }
 
 func (p *Peer) Shutdown() {
+	p.logger.Info("Shutting down")
+
 	p.cancelAll()
 
 	p.reconnectingWg.Wait()
 	p.healthMonitorWg.Wait()
 	p.writerWg.Wait()
 	p.readerWg.Wait()
+
+	p.logger.Info("Shutdown complete")
 }

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -83,6 +83,7 @@ func (pm *PeerManager) GetPeers() []PeerI {
 }
 
 func (pm *PeerManager) Shutdown() {
+	pm.logger.Info("Shutting down peer manager")
 
 	if pm.cancelAll != nil {
 		pm.cancelAll()

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -100,9 +100,7 @@ func (pm *PeerManager) StartMonitorPeerHealth() {
 	for _, peer := range pm.peers {
 		pm.waitGroup.Add(1)
 		go func(p PeerI) {
-			defer func() {
-				pm.waitGroup.Done()
-			}()
+			defer pm.waitGroup.Done()
 			for {
 				select {
 				case <-pm.ctx.Done():

--- a/peer_manager.go
+++ b/peer_manager.go
@@ -21,7 +21,6 @@ type PeerManager struct {
 	logger                *slog.Logger
 	ebs                   int64
 	restartUnhealthyPeers bool
-	monitorPeersInterval  time.Duration
 	waitGroup             sync.WaitGroup
 	cancelAll             context.CancelFunc
 	ctx                   context.Context

--- a/peer_manager_options.go
+++ b/peer_manager_options.go
@@ -16,9 +16,8 @@ func WithExcessiveBlockSize(ebs int64) PeerManagerOptions {
 	}
 }
 
-func WithRestartUnhealthyPeers(monitorPeersInterval time.Duration) PeerManagerOptions {
+func WithRestartUnhealthyPeers() PeerManagerOptions {
 	return func(p *PeerManager) {
 		p.restartUnhealthyPeers = true
-		p.monitorPeersInterval = monitorPeersInterval
 	}
 }

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -39,7 +39,7 @@ func TestNewPeerManager(t *testing.T) {
 		err = pm.AddPeer(peer)
 		require.NoError(t, err)
 		assert.Len(t, pm.GetPeers(), 1)
-		peer.Shutdown()
+		pm.Shutdown()
 	})
 
 	t.Run("1 peer - de dup", func(t *testing.T) {
@@ -64,9 +64,7 @@ func TestNewPeerManager(t *testing.T) {
 
 		assert.Len(t, pm.GetPeers(), 4)
 
-		for _, peer := range peers {
-			peer.Shutdown()
-		}
+		pm.Shutdown()
 	})
 }
 

--- a/peer_mock.go
+++ b/peer_mock.go
@@ -47,6 +47,10 @@ func (p *PeerMock) IsHealthy() bool {
 	return true
 }
 
+func (p *PeerMock) IsUnhealthyCh() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
 func (p *PeerMock) Connected() bool {
 	return true
 }

--- a/peer_options.go
+++ b/peer_options.go
@@ -61,3 +61,14 @@ func WithNrOfWriteHandlers(NrWriteHandlers int) PeerOptions {
 		return nil
 	}
 }
+
+// WithPingInterval sets the optional time duration ping interval and connection health threshold
+// ping interval is the time interval in which the peer sends a ping
+// connection health threshold is the time duration after which the connection is marked unhealthy if no signal is received
+func WithPingInterval(pingInterval time.Duration, connectionHealthThreshold time.Duration) PeerOptions {
+	return func(p *Peer) error {
+		p.pingInterval = pingInterval
+		p.connectionHealthThreshold = connectionHealthThreshold
+		return nil
+	}
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -333,10 +333,10 @@ func TestReconnect(t *testing.T) {
 
 			if tc.cancelRead {
 				// cancel reader so that writer will disconnect
-				peer.stopReadHandler()
+				stopReadHandler(peer)
 			} else {
 				// cancel writer so that reader will disconnect
-				peer.stopWriteHandler()
+				stopWriteHandler(peer)
 			}
 
 			// break connection
@@ -636,4 +636,24 @@ func doHandshake(t *testing.T, p *Peer, myConn net.Conn) {
 	assert.NotEqual(t, 0, n)
 	assert.NoError(t, err)
 	assert.Equal(t, wire.CmdVerAck, msg.Command())
+}
+
+func stopReadHandler(p *Peer) {
+	if p.cancelReadHandler == nil {
+		return
+	}
+	p.logger.Debug("Cancelling read handlers")
+	p.cancelReadHandler()
+	p.logger.Debug("Waiting for read handlers to stop")
+	p.readerWg.Wait()
+}
+
+func stopWriteHandler(p *Peer) {
+	if p.cancelWriteHandler == nil {
+		return
+	}
+	p.logger.Debug("Cancelling write handlers")
+	p.cancelWriteHandler()
+	p.logger.Debug("Waiting for writer handlers to stop")
+	p.writerWg.Wait()
 }

--- a/test/peer_integration_test.go
+++ b/test/peer_integration_test.go
@@ -148,41 +148,4 @@ func TestNewPeer(t *testing.T) {
 		t.Log("shutdown finished")
 	})
 
-	t.Run("announce transaction", func(t *testing.T) {
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-		pm := p2p.NewPeerManager(logger, wire.TestNet)
-		require.NotNil(t, pm)
-
-		peerHandler := &p2p.PeerHandlerIMock{
-			HandleTransactionsGetFunc: func(msgs []*wire.InvVect, peer p2p.PeerI) ([][]byte, error) {
-				return [][]byte{TX1RawBytes}, nil
-			},
-		}
-
-		peer, err := p2p.NewPeer(logger, "localhost:"+p2pPortBinding, peerHandler, wire.TestNet)
-		require.NoError(t, err)
-
-		err = pm.AddPeer(peer)
-		require.NoError(t, err)
-
-		t.Log("expect that peer has connected")
-	connectLoop:
-		for {
-			select {
-			case <-time.NewTicker(200 * time.Millisecond).C:
-				if peer.Connected() {
-					break connectLoop
-				}
-			case <-time.NewTimer(5 * time.Second).C:
-				t.Fatal("peer did not disconnect")
-			}
-		}
-
-		pm.AnnounceTransaction(TX1Hash, []p2p.PeerI{peer})
-
-		time.Sleep(100 * time.Millisecond)
-
-		peer.Shutdown()
-	})
 }

--- a/test/peer_manager_integration_test.go
+++ b/test/peer_manager_integration_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/libsv/go-p2p"
+
+	"github.com/libsv/go-p2p/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPeerManager(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	t.Run("announce transaction", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		pm := p2p.NewPeerManager(logger, wire.TestNet)
+		require.NotNil(t, pm)
+
+		peerHandler := &p2p.PeerHandlerIMock{
+			HandleTransactionsGetFunc: func(msgs []*wire.InvVect, peer p2p.PeerI) ([][]byte, error) {
+				return [][]byte{TX1RawBytes}, nil
+			},
+		}
+
+		peer, err := p2p.NewPeer(logger, "localhost:"+p2pPortBinding, peerHandler, wire.TestNet)
+		require.NoError(t, err)
+
+		err = pm.AddPeer(peer)
+		require.NoError(t, err)
+
+		t.Log("expect that peer has connected")
+	connectLoop:
+		for {
+			select {
+			case <-time.NewTicker(200 * time.Millisecond).C:
+				if peer.Connected() {
+					break connectLoop
+				}
+			case <-time.NewTimer(5 * time.Second).C:
+				t.Fatal("peer did not disconnect")
+			}
+		}
+
+		pm.AnnounceTransaction(TX1Hash, []p2p.PeerI{peer})
+
+		time.Sleep(100 * time.Millisecond)
+
+		peer.Shutdown()
+	})
+}


### PR DESCRIPTION
- Peer health monitoring routine is notified about unhealthy peer
- That triggers restarting of the peer.