### PR TITLE
Merged 0.3.3 spv upgrade

### DIFF
--- a/go-p2p.iml
+++ b/go-p2p.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/interface.go
+++ b/interface.go
@@ -41,4 +41,7 @@ type PeerHandlerI interface {
 	HandleTransaction(msg *wire.MsgTx, peer PeerI) error
 	HandleBlockAnnouncement(msg *wire.InvVect, peer PeerI) error
 	HandleBlock(msg wire.Message, peer PeerI) error
+	HandleHeaders(msg *wire.MsgHeaders, peer PeerI) error
+	HandleVersion(msg *wire.MsgVersion, peer PeerI) error
+	HandleAddresses(msg *wire.MsgAddr, peer PeerI) error
 }

--- a/peer.go
+++ b/peer.go
@@ -55,6 +55,7 @@ type Block struct {
 
 type Peer struct {
 	address                       string
+	lastBlock                     int
 	network                       wire.BitcoinNet
 	mu                            sync.RWMutex
 	readConn                      net.Conn
@@ -90,18 +91,20 @@ type Peer struct {
 }
 
 // NewPeer returns a new bitcoin peer for the provided address and configuration.
-func NewPeer(logger *slog.Logger, address string, peerHandler PeerHandlerI, network wire.BitcoinNet, options ...PeerOptions) (*Peer, error) {
+func NewPeer(logger *slog.Logger, address string, lastBlock int, peerHandler PeerHandlerI, network wire.BitcoinNet, options ...PeerOptions) (*Peer, error) {
 	writeChan := make(chan wire.Message, 10000)
 
 	peerLogger := logger.With(
 		slog.Group("peer",
 			slog.String("network", network.String()),
 			slog.String("address", address),
+			slog.Int("address", lastBlock),
 		),
 	)
 
 	p := &Peer{
 		network:                       network,
+		lastBlock:                     lastBlock,
 		address:                       address,
 		writeChan:                     writeChan,
 		pingPongAlive:                 make(chan struct{}, 1),
@@ -434,6 +437,11 @@ func (p *Peer) startReadHandler(ctx context.Context) {
 						continue
 					}
 
+					versionMsg := msg.(*wire.MsgVersion)
+					if err = p.peerHandler.HandleVersion(versionMsg, p); err != nil {
+						commandLogger.Error("HandlerVersion returned an error.", slog.String(errKey, err.Error()))
+					}
+
 					verackMsg := wire.NewMsgVerAck()
 					if err = wire.WriteMessage(readConn, verackMsg, wire.ProtocolVersion, p.network); err != nil {
 						commandLogger.Error("failed to write message", slog.String(errKey, err.Error()))
@@ -493,6 +501,26 @@ func (p *Peer) startReadHandler(ctx context.Context) {
 					commandLogger.Debug(receivedMsg, slog.String(hashKey, txMsg.TxHash().String()), slog.Int("size", txMsg.SerializeSize()))
 					if err = p.peerHandler.HandleTransaction(txMsg, p); err != nil {
 						commandLogger.Error("Unable to process tx", slog.String(hashKey, txMsg.TxHash().String()), slog.String(errKey, err.Error()))
+					}
+
+				case wire.CmdHeaders:
+					msgHeaders, ok := msg.(*wire.MsgHeaders)
+					if !ok {
+						continue
+					}
+
+					if err = p.peerHandler.HandleHeaders(msgHeaders, p); err != nil {
+						commandLogger.Error("Unable to process headers", slog.String(errKey, err.Error()))
+					}
+
+				case wire.CmdAddr:
+					msgAddress, ok := msg.(*wire.MsgAddr )
+					if !ok {
+						continue
+					}
+
+					if err = p.peerHandler.HandleAddresses(msgAddress, p); err != nil {
+						commandLogger.Error("Unable to process headers", slog.String(errKey, err.Error()))
 					}
 
 				case wire.CmdBlock:
@@ -750,7 +778,6 @@ func (p *Peer) startWriteChannelHandler(ctx context.Context, instance int) {
 }
 
 func (p *Peer) versionMessage(address string) *wire.MsgVersion {
-	lastBlock := int32(0)
 
 	tcpAddrMe := &net.TCPAddr{IP: nil, Port: 0}
 	me := wire.NewNetAddress(tcpAddrMe, wire.SFNodeNetwork)
@@ -773,7 +800,7 @@ func (p *Peer) versionMessage(address string) *wire.MsgVersion {
 		p.logger.Error("RandomUint64: failed to generate nonce", slog.String(errKey, err.Error()))
 	}
 
-	msg := wire.NewMsgVersion(me, you, nonce, lastBlock)
+	msg := wire.NewMsgVersion(me, you, nonce, int32(p.lastBlock))
 
 	if p.userAgentName != nil && p.userAgentVersion != nil {
 		err = msg.AddUserAgent(*p.userAgentName, *p.userAgentVersion)

--- a/peer_handler_gen_mock.go
+++ b/peer_handler_gen_mock.go
@@ -49,6 +49,8 @@ type PeerHandlerIMock struct {
 	// HandleBlockFunc mocks the HandleBlock method.
 	HandleBlockFunc func(msg wire.Message, peer PeerI) error
 
+
+
 	// HandleBlockAnnouncementFunc mocks the HandleBlockAnnouncement method.
 	HandleBlockAnnouncementFunc func(msg *wire.InvVect, peer PeerI) error
 
@@ -66,6 +68,9 @@ type PeerHandlerIMock struct {
 
 	// HandleTransactionsGetFunc mocks the HandleTransactionsGet method.
 	HandleTransactionsGetFunc func(msgs []*wire.InvVect, peer PeerI) ([][]byte, error)
+
+	// HandleHeadersFunc mocks the HandleHeaders method.
+	HandleHeadersFunc func(msg *wire.MsgHeaders, peer PeerI) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -118,6 +123,13 @@ type PeerHandlerIMock struct {
 			// Peer is the peer argument value.
 			Peer PeerI
 		}
+		// HandleHeaders holds details about calls to the HandleHeaders method.
+		HandleHeaders []struct {
+			// Msg is the msg argument value.
+			Msg *wire.MsgHeaders
+			// Peer is the peer argument value.
+			Peer PeerI
+		}
 	}
 	lockHandleBlock                   sync.RWMutex
 	lockHandleBlockAnnouncement       sync.RWMutex
@@ -126,6 +138,16 @@ type PeerHandlerIMock struct {
 	lockHandleTransactionRejection    sync.RWMutex
 	lockHandleTransactionSent         sync.RWMutex
 	lockHandleTransactionsGet         sync.RWMutex
+	lockHandleHeaders                 sync.RWMutex
+}
+
+func (s *PeerHandlerIMock) HandleAddresses(msg *wire.MsgAddr, peer PeerI) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *PeerHandlerIMock) HandleVersion(msg *wire.MsgVersion, peer PeerI) error {
+	return nil
 }
 
 // HandleBlock calls HandleBlockFunc.
@@ -377,5 +399,41 @@ func (mock *PeerHandlerIMock) HandleTransactionsGetCalls() []struct {
 	mock.lockHandleTransactionsGet.RLock()
 	calls = mock.calls.HandleTransactionsGet
 	mock.lockHandleTransactionsGet.RUnlock()
+	return calls
+}
+
+// HandleHeaders calls HandleHeadersFunc.
+func (mock *PeerHandlerIMock) HandleHeaders(msg *wire.MsgHeaders, peer PeerI) error {
+	if mock.HandleHeadersFunc == nil {
+		panic("PeerHandlerIMock.HandleHeadersFunc: method is nil but PeerHandlerI.HandleHeaders was just called")
+	}
+	callInfo := struct {
+		Msg  *wire.MsgHeaders
+		Peer PeerI
+	}{
+		Msg:  msg,
+		Peer: peer,
+	}
+	mock.lockHandleHeaders.Lock()
+	mock.calls.HandleHeaders = append(mock.calls.HandleHeaders, callInfo)
+	mock.lockHandleHeaders.Unlock()
+	return mock.HandleHeadersFunc(msg, peer)
+}
+
+// HandleHeadersCalls gets all the calls that were made to HandleHeaders.
+// Check the length with:
+//
+//	len(mockedPeerHandlerI.HandleHeadersCalls())
+func (mock *PeerHandlerIMock) HandleHeadersCalls() []struct {
+	Msg  *wire.MsgHeaders
+	Peer PeerI
+} {
+	var calls []struct {
+		Msg  *wire.MsgHeaders
+		Peer PeerI
+	}
+	mock.lockHandleHeaders.RLock()
+	calls = mock.calls.HandleHeaders
+	mock.lockHandleHeaders.RUnlock()
 	return calls
 }

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -234,7 +234,7 @@ func NewMsgVersion(me *NetAddress, you *NetAddress, nonce uint64,
 		Nonce:           nonce,
 		UserAgent:       DefaultUserAgent,
 		LastBlock:       lastBlock,
-		DisableRelayTx:  false,
+		DisableRelayTx:  true,
 	}
 }
 


### PR DESCRIPTION
    features: Enhanced PeerHandler; Enhanced Version Msg

    Added additional callbacks to peerhandler for
     HandleHeaders(msg *wire.MsgHeaders, peer PeerI) error
     HandleVersion(msg *wire.MsgVersion, peer PeerI) error
     HandleAddresses(msg *wire.MsgAddr, peer PeerI) error

    These additions make the library useful for use as in an SPV / headers-only client.

    Added the lastBlock to version message announcements. This let's remote peers know
    what an SPV client's known last block is.
